### PR TITLE
SHA-1: fc66445ae3b3011479d7abed63fca4bb1351ba07

### DIFF
--- a/Source/Tools/ContractTools/src/ContractTools.WebApp/Base/TemplateHelper.cs
+++ b/Source/Tools/ContractTools/src/ContractTools.WebApp/Base/TemplateHelper.cs
@@ -328,7 +328,7 @@ namespace ContractTools.WebApp.Base
                                     break;
                                 case FieldType.Bool:
                                 case FieldType.Byte:
-                                    fieldBuilder.Append("writer.getByte(\"");
+                                    fieldBuilder.Append("writer.writeByte(\"");
                                     break;
                                 case FieldType.Float:
                                     fieldBuilder.Append("writer.writeFloat(\"");


### PR DESCRIPTION
* Contract tool Auto generation of C# Client code have problem.

when the Type is Bool

it generate "NetWriter.getByte" should be writeByte

and we need to fix in "Scut Unity Sample" code because there is no such function in itss Netwriter class