### PR TITLE
fix casting exception

### DIFF
--- a/Source/Framework/ZyGames.Framework/Model/AbstractEntity.cs
+++ b/Source/Framework/ZyGames.Framework/Model/AbstractEntity.cs
@@ -783,8 +783,9 @@ namespace ZyGames.Framework.Model
                     }
                     else if (x is long || x is ulong)
                     {
-                        var diff = (long)x - (long)y;
-                        result = diff > 0 ? 1 : diff < 0 ? -1 : 0;
+                        //var diff = (long)x - (long)y;
+                        result = (x.ToLong()).CompareTo(y.ToLong());
+
                     }
                     else if (x is float)
                     {


### PR DESCRIPTION
``` C#
public class UserRole : BaseEntity
 {
        [ProtoMember(1)]
        [EntityField(true)]
        public UInt64 RoleId 
        { 
            get; set; 
        }
        [ProtoMember(2)]
        [EntityField(true)]
        public int UserID 
        { 
            get; set; 
        }
        protected override int GetIdentityId()
        {
            return UserID.ToInt();
        }
}



// below command occur cast exception
var cacheSet = new PersonalCacheStruct<UserRole>();
```

I don't know why this happen now. because i write this long time.
but today it happen problem. and i must change the abstractentity's CompareTo function.
and i suspect the other kind need to be changed (ex. decimal, double, float in CompareTo function
